### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/831/421168831.geojson
+++ b/data/421/168/831/421168831.geojson
@@ -659,6 +659,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459008782,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6551819e9a312ebafaa9790d218c2136",
     "wof:hierarchy":[
         {
@@ -677,7 +680,7 @@
         }
     ],
     "wof:id":421168831,
-    "wof:lastmodified":1566669981,
+    "wof:lastmodified":1582315484,
     "wof:name":"Kathmandu",
     "wof:parent_id":1092048931,
     "wof:placetype":"locality",

--- a/data/421/170/933/421170933.geojson
+++ b/data/421/170/933/421170933.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459008874,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0515398f4aaf2adf5dd4ba74f3f5f014",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":421170933,
-    "wof:lastmodified":1566669993,
+    "wof:lastmodified":1582315485,
     "wof:name":"Baglung",
     "wof:parent_id":1092049257,
     "wof:placetype":"localadmin",

--- a/data/421/172/449/421172449.geojson
+++ b/data/421/172/449/421172449.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459008943,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"972094e1dd9b444a5f9f9166fccaa66e",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":421172449,
-    "wof:lastmodified":1566669988,
+    "wof:lastmodified":1582315484,
     "wof:name":"Arghakhanchi",
     "wof:parent_id":1092049537,
     "wof:placetype":"localadmin",

--- a/data/421/184/573/421184573.geojson
+++ b/data/421/184/573/421184573.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009415,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3dbcf78507f27027ee4a00cd3729f61",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421184573,
-    "wof:lastmodified":1566669992,
+    "wof:lastmodified":1582315485,
     "wof:name":"Parbat",
     "wof:parent_id":1092049089,
     "wof:placetype":"localadmin",

--- a/data/421/185/011/421185011.geojson
+++ b/data/421/185/011/421185011.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009429,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6832da8132f8222d9e459c8584a72ea8",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421185011,
-    "wof:lastmodified":1566669997,
+    "wof:lastmodified":1582315485,
     "wof:name":"Nawalparasi",
     "wof:parent_id":1092050413,
     "wof:placetype":"localadmin",

--- a/data/421/187/749/421187749.geojson
+++ b/data/421/187/749/421187749.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009523,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"693bd264ac80b63784c750606fcbd51b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421187749,
-    "wof:lastmodified":1566669987,
+    "wof:lastmodified":1582315484,
     "wof:name":"Kaski",
     "wof:parent_id":1092049331,
     "wof:placetype":"localadmin",

--- a/data/421/188/593/421188593.geojson
+++ b/data/421/188/593/421188593.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009570,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3adaa21eafd342476067704f08263211",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421188593,
-    "wof:lastmodified":1566669988,
+    "wof:lastmodified":1582315484,
     "wof:name":"Palpa",
     "wof:parent_id":1092050889,
     "wof:placetype":"localadmin",

--- a/data/421/188/601/421188601.geojson
+++ b/data/421/188/601/421188601.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009570,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e94728f6ccd4b3d52e53de32b340519b",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":421188601,
-    "wof:lastmodified":1566669988,
+    "wof:lastmodified":1582315484,
     "wof:name":"Mustang",
     "wof:parent_id":1092048365,
     "wof:placetype":"localadmin",

--- a/data/421/188/603/421188603.geojson
+++ b/data/421/188/603/421188603.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72b5cc29ab7937b33c216123e63aab2b",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":421188603,
-    "wof:lastmodified":1566669988,
+    "wof:lastmodified":1582315484,
     "wof:name":"Myagdi",
     "wof:parent_id":1092049089,
     "wof:placetype":"localadmin",

--- a/data/421/190/173/421190173.geojson
+++ b/data/421/190/173/421190173.geojson
@@ -61,6 +61,9 @@
     },
     "wof:country":"NP",
     "wof:created":1459009649,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e9eaae50e4c4c4672dbba8218e7511d",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":421190173,
-    "wof:lastmodified":1566669990,
+    "wof:lastmodified":1582315484,
     "wof:name":"Syangja",
     "wof:parent_id":1092050939,
     "wof:placetype":"localadmin",

--- a/data/856/324/65/85632465.geojson
+++ b/data/856/324/65/85632465.geojson
@@ -991,6 +991,11 @@
     },
     "wof:country":"NP",
     "wof:country_alpha3":"NPL",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"fd3572c6dd735aed0e110830f1166e30",
     "wof:hierarchy":[
         {
@@ -1005,7 +1010,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1566665529,
+    "wof:lastmodified":1582315407,
     "wof:name":"Nepal",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/037/71/85903771.geojson
+++ b/data/859/037/71/85903771.geojson
@@ -97,6 +97,9 @@
         "qs_pg:id":241184
     },
     "wof:country":"NP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51ea0978f6e609862d0bdf6c07728d13",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566665527,
+    "wof:lastmodified":1582315406,
     "wof:name":"Thapathali",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.