### PR TITLE
Update megacity records

### DIFF
--- a/data/421/168/831/421168831.geojson
+++ b/data/421/168/831/421168831.geojson
@@ -655,6 +655,7 @@
         "gn:id":1283240,
         "gp:id":2269179,
         "loc:id":"n81047119",
+        "ne:id":1159150655,
         "qs_pg:id":1168582,
         "wd:id":"Q3037",
         "wk:page":"Kathmandu"
@@ -685,7 +686,8 @@
         }
     ],
     "wof:id":421168831,
-    "wof:lastmodified":1608003915,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Kathmandu",
     "wof:parent_id":1092048931,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary