### PR TITLE
np concordances, placetype local, and more

### DIFF
--- a/data/109/204/805/1/1092048051.geojson
+++ b/data/109/204/805/1/1092048051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116631,
-    "geom:area_square_m":1283757806.355895,
+    "geom:area_square_m":1283757718.956552,
     "geom:bbox":"84.876404,26.846941,85.265259,27.364791",
     "geom:latitude":27.105985,
     "geom:longitude":85.069968,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.TW.BA",
         "wd:id":"Q28608"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898435,
-    "wof:geomhash":"8c35fe6c3df63e244040fa4b2944d322",
+    "wof:geomhash":"6e76cb39441053d4b4cf4fb76e85edbb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092048051,
-    "wof:lastmodified":1690849696,
+    "wof:lastmodified":1695886586,
     "wof:name":"Bara",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/809/7/1092048097.geojson
+++ b/data/109/204/809/7/1092048097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186216,
-    "geom:area_square_m":2025838726.056988,
+    "geom:area_square_m":2025839030.383602,
     "geom:bbox":"81.058238,28.069252,81.765315,28.674612",
     "geom:latitude":28.380719,
     "geom:longitude":81.401829,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.FI.BR",
         "wd:id":"Q28458"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898436,
-    "wof:geomhash":"155aad322a638fdc10e79cebebda1948",
+    "wof:geomhash":"6c1c5023aceaf5f33815eb2d0aab97d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092048097,
-    "wof:lastmodified":1690849703,
+    "wof:lastmodified":1695886588,
     "wof:name":"Bardiya",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/812/7/1092048127.geojson
+++ b/data/109/204/812/7/1092048127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109985,
-    "geom:area_square_m":1213624843.671175,
+    "geom:area_square_m":1213624619.157498,
     "geom:bbox":"85.843261,26.570277,86.259181,27.133968",
     "geom:latitude":26.825653,
     "geom:longitude":86.033378,
@@ -162,9 +162,10 @@
         "hasc:id":"NP.TW.DN",
         "wd:id":"Q29036"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898438,
-    "wof:geomhash":"ac32bdbbeddcf5f39974953f61515efa",
+    "wof:geomhash":"9ba6d698014406d1f2e377862afd234c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1092048127,
-    "wof:lastmodified":1690849700,
+    "wof:lastmodified":1695886587,
     "wof:name":"Dhanusa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/817/3/1092048173.geojson
+++ b/data/109/204/817/3/1092048173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153438,
-    "geom:area_square_m":1692280871.038946,
+    "geom:area_square_m":1692281043.580312,
     "geom:bbox":"87.606717,26.664754,88.182506,27.109421",
     "geom:latitude":26.881063,
     "geom:longitude":87.901977,
@@ -197,9 +197,10 @@
         "hasc:id":"NP.ON.IL",
         "wd:id":"Q29016"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898439,
-    "wof:geomhash":"a6ca35e650d6c833a3920a10e1aa6c74",
+    "wof:geomhash":"881dc8ad172a7d0c3159bd635e97afa9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":1092048173,
-    "wof:lastmodified":1690849695,
+    "wof:lastmodified":1695886622,
     "wof:name":"Ilam",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/822/7/1092048227.geojson
+++ b/data/109/204/822/7/1092048227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152508,
-    "geom:area_square_m":1651581354.45167,
+    "geom:area_square_m":1651581302.37757,
     "geom:bbox":"80.052222,28.566945,80.554371,29.129143",
     "geom:latitude":28.85956,
     "geom:longitude":80.319615,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.SE.KN",
         "wd:id":"Q28981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898441,
-    "wof:geomhash":"309aa788369e03ed1059b73849e0cba8",
+    "wof:geomhash":"3571c46eb6b139e20d2a60ae1c7e094d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092048227,
-    "wof:lastmodified":1690849702,
+    "wof:lastmodified":1695886588,
     "wof:name":"Kanchanpur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/825/9/1092048259.geojson
+++ b/data/109/204/825/9/1092048259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152493,
-    "geom:area_square_m":1670634290.533418,
+    "geom:area_square_m":1670634026.737406,
     "geom:bbox":"82.697575,27.413305,83.232171,27.80972",
     "geom:latitude":27.625702,
     "geom:longitude":82.982558,
@@ -165,9 +165,10 @@
         "hasc:id":"NP.FI.KP",
         "wd:id":"Q28574"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898443,
-    "wof:geomhash":"d25bcacde3d9509b11ddb8ee983579db",
+    "wof:geomhash":"428688e573f45aa946de97e53bbbcb8c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":1092048259,
-    "wof:lastmodified":1690849702,
+    "wof:lastmodified":1695886588,
     "wof:name":"Kapilvastu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/830/3/1092048303.geojson
+++ b/data/109/204/830/3/1092048303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166581,
-    "geom:area_square_m":1841529954.827834,
+    "geom:area_square_m":1841529775.115185,
     "geom:bbox":"87.240185,26.347779,87.688049,26.872954",
     "geom:latitude":26.615777,
     "geom:longitude":87.470032,
@@ -188,9 +188,10 @@
         "hasc:id":"NP.ON.MO",
         "wd:id":"Q28083"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898445,
-    "wof:geomhash":"9260033f3496ffe45e8b62e32f22f347",
+    "wof:geomhash":"6806bf3e6a01bcb8e6aecb4482936da5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1092048303,
-    "wof:lastmodified":1690849703,
+    "wof:lastmodified":1695886588,
     "wof:name":"Morang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/833/9/1092048339.geojson
+++ b/data/109/204/833/9/1092048339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301841,
-    "geom:area_square_m":3244640838.159967,
+    "geom:area_square_m":3244641337.282784,
     "geom:bbox":"81.772148,29.38792,82.830235,29.972428",
     "geom:latitude":29.61831,
     "geom:longitude":82.370959,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.SI.MG",
         "wd:id":"Q28593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898446,
-    "wof:geomhash":"b62468537a51a83fb36f0241e0a00591",
+    "wof:geomhash":"bb22c162f1d33a01390c66bedd77a795",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092048339,
-    "wof:lastmodified":1690849696,
+    "wof:lastmodified":1695886586,
     "wof:name":"Mugu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/836/5/1092048365.geojson
+++ b/data/109/204/836/5/1092048365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329966,
-    "geom:area_square_m":3569156394.8488,
+    "geom:area_square_m":3569156785.633487,
     "geom:bbox":"83.479657,28.565172,84.251714,29.330612",
     "geom:latitude":28.981493,
     "geom:longitude":83.857697,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.FO.MS",
         "wd:id":"Q2239575"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898448,
-    "wof:geomhash":"46c7258ba914f39f931136a6e63c3636",
+    "wof:geomhash":"e23b4a1b7ff4c3b3820236325b8d034b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092048365,
-    "wof:lastmodified":1690849702,
+    "wof:lastmodified":1695886589,
     "wof:name":"Mustang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/840/9/1092048409.geojson
+++ b/data/109/204/840/9/1092048409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137682,
-    "geom:area_square_m":1500623242.925432,
+    "geom:area_square_m":1500622749.009657,
     "geom:bbox":"85.120066,27.967306,85.800249,28.385833",
     "geom:latitude":28.182862,
     "geom:longitude":85.415055,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TH.RS",
         "wd:id":"Q28605"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898449,
-    "wof:geomhash":"3d886b79a160ae1db8df4c6b45a68ae9",
+    "wof:geomhash":"f2accce334302f8f722cd4085bda3f78",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092048409,
-    "wof:lastmodified":1690849701,
+    "wof:lastmodified":1695886589,
     "wof:name":"Rasuwa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/845/7/1092048457.geojson
+++ b/data/109/204/845/7/1092048457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119056,
-    "geom:area_square_m":1304888463.735734,
+    "geom:area_square_m":1304888149.822728,
     "geom:bbox":"83.206905,27.335555,83.633227,27.766312",
     "geom:latitude":27.577316,
     "geom:longitude":83.389182,
@@ -176,9 +176,10 @@
         "hasc:id":"NP.FI.RP",
         "wd:id":"Q28438"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898451,
-    "wof:geomhash":"ba5bf76120c9d7454f7b6c77ec868a61",
+    "wof:geomhash":"ad5d8839a21778a0b7af73220cd8afea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":1092048457,
-    "wof:lastmodified":1690849694,
+    "wof:lastmodified":1695886585,
     "wof:name":"Rupandehi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/848/5/1092048485.geojson
+++ b/data/109/204/848/5/1092048485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116959,
-    "geom:area_square_m":1293177197.704072,
+    "geom:area_square_m":1293177080.368533,
     "geom:bbox":"86.483114,26.419723,87.013187,26.790556",
     "geom:latitude":26.597004,
     "geom:longitude":86.743893,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TW.ST",
         "wd:id":"Q28613"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898452,
-    "wof:geomhash":"aeb3b814220725a0f34c885a5d3ff497",
+    "wof:geomhash":"84b00009e766c30d101f78399df2a8b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092048485,
-    "wof:lastmodified":1690849700,
+    "wof:lastmodified":1695886587,
     "wof:name":"Saptari",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/852/7/1092048527.geojson
+++ b/data/109/204/852/7/1092048527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157456,
-    "geom:area_square_m":1700985739.605484,
+    "geom:area_square_m":1700986225.57659,
     "geom:bbox":"81.029943,28.746996,81.581855,29.393139",
     "geom:latitude":29.113197,
     "geom:longitude":81.296749,
@@ -170,9 +170,10 @@
         "hasc:id":"NP.SE.AC",
         "wd:id":"Q28426"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898454,
-    "wof:geomhash":"9e4f6aff881c4284b6e64886c982e051",
+    "wof:geomhash":"bd6d1fc240ccb8c1e599e07c8d5acd95",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1092048527,
-    "wof:lastmodified":1690849703,
+    "wof:lastmodified":1695886589,
     "wof:name":"Achham",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/857/1/1092048571.geojson
+++ b/data/109/204/857/1/1092048571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.322748,
-    "geom:area_square_m":3466280372.900966,
+    "geom:area_square_m":3466280153.271699,
     "geom:bbox":"80.748081,29.39049,81.56307,30.053759",
     "geom:latitude":29.708022,
     "geom:longitude":81.17823,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.SE.BH",
         "wd:id":"Q28592"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898455,
-    "wof:geomhash":"71d5dfb10a5ac931c5bf9abf1e0d46e1",
+    "wof:geomhash":"a7e165b4dad16dba8dc594bfb2f5496d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092048571,
-    "wof:lastmodified":1690849695,
+    "wof:lastmodified":1695886586,
     "wof:name":"Bajhang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/860/5/1092048605.geojson
+++ b/data/109/204/860/5/1092048605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284965,
-    "geom:area_square_m":3112177519.513037,
+    "geom:area_square_m":3112177667.617183,
     "geom:bbox":"81.92081,27.671667,82.80618,28.281884",
     "geom:latitude":27.96554,
     "geom:longitude":82.402286,
@@ -160,9 +160,10 @@
         "hasc:id":"NP.FI.DA",
         "wd:id":"Q28066"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898457,
-    "wof:geomhash":"ce047d9fa407b576242791f1538db63a",
+    "wof:geomhash":"dc99ccb94a048935ac848a7ca57c3081",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1092048605,
-    "wof:lastmodified":1690849696,
+    "wof:lastmodified":1695886586,
     "wof:name":"Dang Deokhuri",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/865/3/1092048653.geojson
+++ b/data/109/204/865/3/1092048653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189675,
-    "geom:area_square_m":2047930138.714817,
+    "geom:area_square_m":2047930033.30282,
     "geom:bbox":"80.527313,28.932326,81.162793,29.44266",
     "geom:latitude":29.169279,
     "geom:longitude":80.893672,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.SE.DT",
         "wd:id":"Q28600"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898459,
-    "wof:geomhash":"4fe7e3b3deb0a6b247d09f9199012437",
+    "wof:geomhash":"a6403900f83711a187af866f19983fe3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092048653,
-    "wof:lastmodified":1690849703,
+    "wof:lastmodified":1695886589,
     "wof:name":"Doti",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/869/7/1092048697.geojson
+++ b/data/109/204/869/7/1092048697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140996,
-    "geom:area_square_m":1521548829.325942,
+    "geom:area_square_m":1521548731.393178,
     "geom:bbox":"80.184067,28.993071,80.784583,29.423398",
     "geom:latitude":29.222764,
     "geom:longitude":80.486185,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.SE.DD",
         "wd:id":"Q28594"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898460,
-    "wof:geomhash":"f797ab4ef37365f353e93c2c889c5783",
+    "wof:geomhash":"1392850ad39b2bede61975db6efa5445",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092048697,
-    "wof:lastmodified":1690849695,
+    "wof:lastmodified":1695886586,
     "wof:name":"Dadeldhura",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/874/3/1092048743.geojson
+++ b/data/109/204/874/3/1092048743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.305768,
-    "geom:area_square_m":3315119212.484115,
+    "geom:area_square_m":3315119324.425949,
     "geom:bbox":"80.469213,28.400825,81.288542,29.063907",
     "geom:latitude":28.739779,
     "geom:longitude":80.878923,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.SE.KL",
         "wd:id":"Q28153"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898461,
-    "wof:geomhash":"ef0ce69b7e906a56cf58febfb23201ef",
+    "wof:geomhash":"0932868b7809e36315fb84294eb047ce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092048743,
-    "wof:lastmodified":1690849694,
+    "wof:lastmodified":1695886585,
     "wof:name":"Kailali",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/876/3/1092048763.geojson
+++ b/data/109/204/876/3/1092048763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205619,
-    "geom:area_square_m":2226622429.73092,
+    "geom:area_square_m":2226621986.197564,
     "geom:bbox":"81.818697,28.610337,82.571733,29.126443",
     "geom:latitude":28.865244,
     "geom:longitude":82.167763,
@@ -155,9 +155,10 @@
         "hasc:id":"NP.SI.JA",
         "wd:id":"Q29430"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898463,
-    "wof:geomhash":"5d14e39c2532b425c5369c9fead36514",
+    "wof:geomhash":"9a68097ec7f1980e8a97c4ef3519001d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1092048763,
-    "wof:lastmodified":1690849701,
+    "wof:lastmodified":1695886588,
     "wof:name":"Jajarkot",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/880/9/1092048809.geojson
+++ b/data/109/204/880/9/1092048809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.152428,
-    "geom:area_square_m":1645365188.222986,
+    "geom:area_square_m":1645365326.618376,
     "geom:bbox":"81.470288,28.97008,82.018733,29.460777",
     "geom:latitude":29.195102,
     "geom:longitude":81.752266,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.SI.KK",
         "wd:id":"Q28102"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898464,
-    "wof:geomhash":"3bb30b56aff774cfc1d92227a9f700d7",
+    "wof:geomhash":"8da87e9ab10e98f6b47510794ae7bbcc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092048809,
-    "wof:lastmodified":1690849694,
+    "wof:lastmodified":1695886585,
     "wof:name":"Kalikot",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/885/3/1092048853.geojson
+++ b/data/109/204/885/3/1092048853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011243,
-    "geom:area_square_m":123118827.173376,
+    "geom:area_square_m":123118596.675988,
     "geom:bbox":"85.355076,27.618269,85.522718,27.73048",
     "geom:latitude":27.677756,
     "geom:longitude":85.440517,
@@ -176,9 +176,10 @@
         "hasc:id":"NP.TH.BK",
         "wd:id":"Q28451"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898466,
-    "wof:geomhash":"e7b543a6fa3774c42755ef098a8dda6a",
+    "wof:geomhash":"1f0dd306cc42ea25d0f336491044b230",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":1092048853,
-    "wof:lastmodified":1690849701,
+    "wof:lastmodified":1695886588,
     "wof:name":"Bhaktapur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/888/7/1092048887.geojson
+++ b/data/109/204/888/7/1092048887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127776,
-    "geom:area_square_m":1400992715.215533,
+    "geom:area_square_m":1400992915.956383,
     "geom:bbox":"85.392689,27.335331,85.877237,27.754698",
     "geom:latitude":27.535729,
     "geom:longitude":85.618998,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.TH.KV",
         "wd:id":"Q28569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898467,
-    "wof:geomhash":"154759e22924628e2714adbbc9617c01",
+    "wof:geomhash":"fb691b86f4b9096b1d3737755e73e888",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092048887,
-    "wof:lastmodified":1690849695,
+    "wof:lastmodified":1695886586,
     "wof:name":"KavrePalanchok",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/893/1/1092048931.geojson
+++ b/data/109/204/893/1/1092048931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03802,
-    "geom:area_square_m":416136800.549083,
+    "geom:area_square_m":416136800.549021,
     "geom:bbox":"85.188721,27.571345,85.564449,27.816314",
     "geom:latitude":27.728185,
     "geom:longitude":85.347479,
@@ -179,12 +179,13 @@
         "hasc:id":"NP.TH.KT",
         "wd:id":"Q797472"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421168831
     ],
     "wof:country":"NP",
     "wof:created":1473898468,
-    "wof:geomhash":"866b3412ea0e09533fd1b1e18802e7ac",
+    "wof:geomhash":"3a5d241ae61d3e258f2d2291d08a2f1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1092048931,
-    "wof:lastmodified":1690849696,
+    "wof:lastmodified":1695886415,
     "wof:name":"Kathmandu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/897/1/1092048971.geojson
+++ b/data/109/204/897/1/1092048971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035943,
-    "geom:area_square_m":394085703.231002,
+    "geom:area_square_m":394085863.907795,
     "geom:bbox":"85.234175,27.402897,85.442011,27.691039",
     "geom:latitude":27.539199,
     "geom:longitude":85.342263,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.TH.LL",
         "wd:id":"Q1108338"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898470,
-    "wof:geomhash":"3cede8ecdb820e6a4898df84e669606b",
+    "wof:geomhash":"5314e3487b07ecb3068bc03e4eaa16ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092048971,
-    "wof:lastmodified":1690849704,
+    "wof:lastmodified":1695886589,
     "wof:name":"Lalitpur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/901/7/1092049017.geojson
+++ b/data/109/204/901/7/1092049017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223431,
-    "geom:area_square_m":2451268818.860427,
+    "geom:area_square_m":2451268506.472816,
     "geom:bbox":"84.66421,27.160313,85.506521,27.7135",
     "geom:latitude":27.470055,
     "geom:longitude":85.078572,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.TH.MK",
         "wd:id":"Q28174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898471,
-    "wof:geomhash":"4b1f90d1381682752ecca2071ecd745a",
+    "wof:geomhash":"ddd850fea82cf43ad006e79fcc92facf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092049017,
-    "wof:lastmodified":1690849693,
+    "wof:lastmodified":1695886585,
     "wof:name":"Makwanpur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/904/1/1092049041.geojson
+++ b/data/109/204/904/1/1092049041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214094,
-    "geom:area_square_m":2322671183.944153,
+    "geom:area_square_m":2322670776.435462,
     "geom:bbox":"83.789859,28.44644,84.569456,28.899496",
     "geom:latitude":28.673126,
     "geom:longitude":84.224548,
@@ -170,9 +170,10 @@
         "hasc:id":"NP.FO.MN",
         "wd:id":"Q28434"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898473,
-    "wof:geomhash":"835ef629353fb6aa48159ce37767dba1",
+    "wof:geomhash":"d86a023b7e49af548367bbdfd4c5706b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1092049041,
-    "wof:lastmodified":1690849699,
+    "wof:lastmodified":1695886587,
     "wof:name":"Manang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/908/9/1092049089.geojson
+++ b/data/109/204/908/9/1092049089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.210677,
-    "geom:area_square_m":2288202268.618484,
+    "geom:area_square_m":2288202053.728788,
     "geom:bbox":"83.099913,28.306164,83.871821,28.792823",
     "geom:latitude":28.553813,
     "geom:longitude":83.459404,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.FO.MY",
         "wd:id":"Q28624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898474,
-    "wof:geomhash":"ce1a6d35735aefe89db1e37365738002",
+    "wof:geomhash":"feae7be57aa26453bfe6e027ac0822b1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049089,
-    "wof:lastmodified":1690849693,
+    "wof:lastmodified":1695886585,
     "wof:name":"Myagdi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/913/3/1092049133.geojson
+++ b/data/109/204/913/3/1092049133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109338,
-    "geom:area_square_m":1194668573.651727,
+    "geom:area_square_m":1194668848.792385,
     "geom:bbox":"84.988833,27.761138,85.497612,28.091942",
     "geom:latitude":27.915269,
     "geom:longitude":85.235155,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TH.NU",
         "wd:id":"Q28430"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898476,
-    "wof:geomhash":"995aba76a448687414cc6914e9cce7bb",
+    "wof:geomhash":"b8212dd2c6945d4e307cb2d58bd7655e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092049133,
-    "wof:lastmodified":1690849698,
+    "wof:lastmodified":1695886587,
     "wof:name":"Nuwakot",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/916/5/1092049165.geojson
+++ b/data/109/204/916/5/1092049165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114273,
-    "geom:area_square_m":1257696399.537049,
+    "geom:area_square_m":1257696160.079292,
     "geom:bbox":"87.496681,26.858626,88.078537,27.421892",
     "geom:latitude":27.11555,
     "geom:longitude":87.777159,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.ON.PN",
         "wd:id":"Q28155"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898477,
-    "wof:geomhash":"db76d02ce35dcf28d04300b83f476e80",
+    "wof:geomhash":"e1f162d60a14022ee91aa83e446372f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049165,
-    "wof:lastmodified":1690849704,
+    "wof:lastmodified":1695886589,
     "wof:name":"Panchthar",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/920/7/1092049207.geojson
+++ b/data/109/204/920/7/1092049207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081807,
-    "geom:area_square_m":901373703.207707,
+    "geom:area_square_m":901373163.230449,
     "geom:bbox":"87.151559,26.847477,87.572488,27.191441",
     "geom:latitude":26.991205,
     "geom:longitude":87.330599,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.ON.DK",
         "wd:id":"Q28081"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898478,
-    "wof:geomhash":"67f85ddecab00c0442085a00f7052f75",
+    "wof:geomhash":"2854e3318a9c4899d92c77668a182772",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092049207,
-    "wof:lastmodified":1690849704,
+    "wof:lastmodified":1695886589,
     "wof:name":"Dhankuta",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/925/7/1092049257.geojson
+++ b/data/109/204/925/7/1092049257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169236,
-    "geom:area_square_m":1841692421.645806,
+    "geom:area_square_m":1841692797.07651,
     "geom:bbox":"82.878881,28.078546,83.673495,28.63522",
     "geom:latitude":28.347452,
     "geom:longitude":83.250369,
@@ -185,9 +185,10 @@
         "hasc:id":"NP.FO.BG",
         "wd:id":"Q28162"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898480,
-    "wof:geomhash":"136f4fc943fd3520e6fe73a9740d97b4",
+    "wof:geomhash":"4681ba486727b0968d776c29867af3f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -203,7 +204,7 @@
         }
     ],
     "wof:id":1092049257,
-    "wof:lastmodified":1690849698,
+    "wof:lastmodified":1695886622,
     "wof:name":"Baglung",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/929/7/1092049297.geojson
+++ b/data/109/204/929/7/1092049297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04999,
-    "geom:area_square_m":544703668.823242,
+    "geom:area_square_m":544703477.609955,
     "geom:bbox":"83.559314,28.008422,83.822681,28.401007",
     "geom:latitude":28.212068,
     "geom:longitude":83.678554,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.FO.PB",
         "wd:id":"Q28421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898481,
-    "wof:geomhash":"b03f2e29d0ca4679bbd9772c29500d02",
+    "wof:geomhash":"5174cd8f54476eb30d9eb858a9c3d9ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049297,
-    "wof:lastmodified":1690849704,
+    "wof:lastmodified":1695886589,
     "wof:name":"Parbat",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/933/1/1092049331.geojson
+++ b/data/109/204/933/1/1092049331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192102,
-    "geom:area_square_m":2090367413.852871,
+    "geom:area_square_m":2090367625.81825,
     "geom:bbox":"83.70405,28.082406,84.276246,28.615387",
     "geom:latitude":28.35542,
     "geom:longitude":83.996896,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.FO.KS",
         "wd:id":"Q28436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898483,
-    "wof:geomhash":"f7e2f5b47e41eb224ecfecedee59164a",
+    "wof:geomhash":"96ddf4cdfa1fc4c1d0dd9aa0d433fcda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092049331,
-    "wof:lastmodified":1690849700,
+    "wof:lastmodified":1695886588,
     "wof:name":"Kaski",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/937/7/1092049377.geojson
+++ b/data/109/204/937/7/1092049377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121208,
-    "geom:area_square_m":1321903075.004143,
+    "geom:area_square_m":1321902592.938371,
     "geom:bbox":"82.591353,27.877431,83.096428,28.361089",
     "geom:latitude":28.115371,
     "geom:longitude":82.86479,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.FI.PY",
         "wd:id":"Q28094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898484,
-    "wof:geomhash":"e5a97e77e4d4941e269a5d26a03d5e55",
+    "wof:geomhash":"1e4e1f4821817810380f4462ae760148",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049377,
-    "wof:lastmodified":1690849693,
+    "wof:lastmodified":1695886585,
     "wof:name":"Pyuthan",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/941/9/1092049419.geojson
+++ b/data/109/204/941/9/1092049419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094438,
-    "geom:area_square_m":1040461952.280349,
+    "geom:area_square_m":1040461921.562283,
     "geom:bbox":"85.166845,26.735954,85.492577,27.231595",
     "geom:latitude":27.000608,
     "geom:longitude":85.302506,
@@ -155,9 +155,10 @@
         "hasc:id":"NP.TW.RT",
         "wd:id":"Q28098"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898486,
-    "wof:geomhash":"00cc7ff6682899d655b4a1cfa47adbdb",
+    "wof:geomhash":"235559d15b4153af9692e99c13b71894",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1092049419,
-    "wof:lastmodified":1690849697,
+    "wof:lastmodified":1695886587,
     "wof:name":"Rautahat",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/945/5/1092049455.geojson
+++ b/data/109/204/945/5/1092049455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173447,
-    "geom:area_square_m":1887572926.919993,
+    "geom:area_square_m":1887572944.799231,
     "geom:bbox":"82.350845,28.094943,82.956691,28.557303",
     "geom:latitude":28.34423,
     "geom:longitude":82.627994,
@@ -155,9 +155,10 @@
         "hasc:id":"NP.FI.RO",
         "wd:id":"Q28597"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898487,
-    "wof:geomhash":"6edbf482e6814bfe7c5a412250f623cc",
+    "wof:geomhash":"f559fd7ae950277e7adc0cdd43a6ba36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1092049455,
-    "wof:lastmodified":1690849705,
+    "wof:lastmodified":1695886589,
     "wof:name":"Rolpa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/949/5/1092049495.geojson
+++ b/data/109/204/949/5/1092049495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.26757,
-    "geom:area_square_m":2902044012.187037,
+    "geom:area_square_m":2902044012.186716,
     "geom:bbox":"82.1893377144,28.4765107108,83.1513377649,28.9933029665",
     "geom:latitude":28.701503,
     "geom:longitude":82.664256,
@@ -152,9 +152,10 @@
         "hasc:id":"NP.FI.RK",
         "wd:id":"Q28612"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898489,
-    "wof:geomhash":"3fa8b37b19a5678fa8080694faa2ab04",
+    "wof:geomhash":"efde09574286a5c3752b01fbc72cb381",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1092049495,
-    "wof:lastmodified":1566669762,
+    "wof:lastmodified":1695886587,
     "wof:name":"Rukum",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/953/7/1092049537.geojson
+++ b/data/109/204/953/7/1092049537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113785,
-    "geom:area_square_m":1243336278.761633,
+    "geom:area_square_m":1243336656.658722,
     "geom:bbox":"82.749998,27.75305,83.327272,28.111898",
     "geom:latitude":27.9081,
     "geom:longitude":83.078885,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.FI.AR",
         "wd:id":"Q28432"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898490,
-    "wof:geomhash":"ad01efc6f20120a365fe4eede1080c2c",
+    "wof:geomhash":"880e653f8030ecb1f268a1df3fb406f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092049537,
-    "wof:lastmodified":1690849692,
+    "wof:lastmodified":1695886585,
     "wof:name":"Arghakhanchi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/957/9/1092049579.geojson
+++ b/data/109/204/957/9/1092049579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172906,
-    "geom:area_square_m":1880660700.182952,
+    "geom:area_square_m":1880660445.290161,
     "geom:bbox":"81.742036,28.185323,82.432249,28.642667",
     "geom:latitude":28.402462,
     "geom:longitude":82.14371,
@@ -179,9 +179,10 @@
         "hasc:id":"NP.SI.SL",
         "wd:id":"Q28571"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898492,
-    "wof:geomhash":"145186f7c6c0b7c475cf69bf83b55633",
+    "wof:geomhash":"25486681569f87d57d4edffe4d148361",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -197,7 +198,7 @@
         }
     ],
     "wof:id":1092049579,
-    "wof:lastmodified":1690849698,
+    "wof:lastmodified":1695886622,
     "wof:name":"Salyan",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/959/7/1092049597.geojson
+++ b/data/109/204/959/7/1092049597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317281,
-    "geom:area_square_m":3477329788.235755,
+    "geom:area_square_m":3477330054.889214,
     "geom:bbox":"86.942423,27.138421,87.675855,27.957924",
     "geom:latitude":27.582445,
     "geom:longitude":87.278194,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.ON.SS",
         "wd:id":"Q28596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898493,
-    "wof:geomhash":"2fbdbf180d79db466672c336dea4927d",
+    "wof:geomhash":"3581f5c2638cee13f7361d3879927469",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092049597,
-    "wof:lastmodified":1690849699,
+    "wof:lastmodified":1695886587,
     "wof:name":"Sankhuwasabha",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/963/9/1092049639.geojson
+++ b/data/109/204/963/9/1092049639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115393,
-    "geom:area_square_m":1271499121.921839,
+    "geom:area_square_m":1271498922.07177,
     "geom:bbox":"85.323239,26.735834,85.813123,27.193589",
     "geom:latitude":26.985934,
     "geom:longitude":85.565519,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.TW.SA",
         "wd:id":"Q28074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898494,
-    "wof:geomhash":"a795617a42a30b71f64da7e15274f3e8",
+    "wof:geomhash":"0fd05f3eb63df5991e3d5ddd9b1eedbe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049639,
-    "wof:lastmodified":1690849693,
+    "wof:lastmodified":1695886586,
     "wof:name":"Sarlahi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/967/9/1092049679.geojson
+++ b/data/109/204/967/9/1092049679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226219,
-    "geom:area_square_m":2487871577.411265,
+    "geom:area_square_m":2487871720.683281,
     "geom:bbox":"85.420591,26.925919,86.386671,27.451462",
     "geom:latitude":27.201659,
     "geom:longitude":85.943585,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TH.SI",
         "wd:id":"Q28586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898496,
-    "wof:geomhash":"de7c66101cb51c4f536445b3fd752668",
+    "wof:geomhash":"c37abd363b5541d869bc8c9c5dcc2452",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092049679,
-    "wof:lastmodified":1690849699,
+    "wof:lastmodified":1695886588,
     "wof:name":"Sindhuli",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/971/1/1092049711.geojson
+++ b/data/109/204/971/1/1092049711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142884,
-    "geom:area_square_m":1566956855.283407,
+    "geom:area_square_m":1566956452.502543,
     "geom:bbox":"85.800668,27.245026,86.571415,27.830454",
     "geom:latitude":27.513657,
     "geom:longitude":86.177165,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.TH.RM",
         "wd:id":"Q28611"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898497,
-    "wof:geomhash":"1e8c158a72c7c971731467100efd497f",
+    "wof:geomhash":"537ef9780f4ec556bb7e528bf245bafa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092049711,
-    "wof:lastmodified":1690849697,
+    "wof:lastmodified":1695886622,
     "wof:name":"Ramechhap",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/975/5/1092049755.geojson
+++ b/data/109/204/975/5/1092049755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22799,
-    "geom:area_square_m":2491101477.619501,
+    "geom:area_square_m":2491101411.972244,
     "geom:bbox":"85.439509,27.613085,86.059167,28.202551",
     "geom:latitude":27.915273,
     "geom:longitude":85.739427,
@@ -168,9 +168,10 @@
         "hasc:id":"NP.TH.SP",
         "wd:id":"Q28445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898499,
-    "wof:geomhash":"d25a4b4f503b32fb207ddbda1837c160",
+    "wof:geomhash":"5500f7bcc3641cbb67d7d27bcc49dc64",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":1092049755,
-    "wof:lastmodified":1690849705,
+    "wof:lastmodified":1695886590,
     "wof:name":"Sindhupalchok",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/981/3/1092049813.geojson
+++ b/data/109/204/981/3/1092049813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331754,
-    "geom:area_square_m":3635960576.790039,
+    "geom:area_square_m":3635960655.485055,
     "geom:bbox":"87.446096,27.269167,88.199298,27.952443",
     "geom:latitude":27.582112,
     "geom:longitude":87.821859,
@@ -170,9 +170,10 @@
         "hasc:id":"NP.ON.TP",
         "wd:id":"Q28590"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898501,
-    "wof:geomhash":"9cd4525adf581903f05b87c43dd4a349",
+    "wof:geomhash":"c53de7f8661ff417414848a910585ac5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1092049813,
-    "wof:lastmodified":1690849705,
+    "wof:lastmodified":1695886590,
     "wof:name":"Taplejung",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/984/1/1092049841.geojson
+++ b/data/109/204/984/1/1092049841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307038,
-    "geom:area_square_m":3361126397.667622,
+    "geom:area_square_m":3361126104.25916,
     "geom:bbox":"86.35723,27.338469,87.006584,28.11375",
     "geom:latitude":27.710575,
     "geom:longitude":86.720276,
@@ -188,9 +188,10 @@
         "hasc:id":"NP.ON.SO",
         "wd:id":"Q28363"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898502,
-    "wof:geomhash":"4a0693688c84a6fa38749227bbfbeb6c",
+    "wof:geomhash":"a44116a04179b6023ffa21aa5a420355",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1092049841,
-    "wof:lastmodified":1690849697,
+    "wof:lastmodified":1695886587,
     "wof:name":"Solukhumbu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/988/3/1092049883.geojson
+++ b/data/109/204/988/3/1092049883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138844,
-    "geom:area_square_m":1527213975.439722,
+    "geom:area_square_m":1527214242.491204,
     "geom:bbox":"86.897226,26.888615,87.274719,27.461562",
     "geom:latitude":27.182208,
     "geom:longitude":87.067702,
@@ -227,9 +227,10 @@
         "hasc:id":"NP.ON.BJ",
         "wd:id":"Q2284812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898504,
-    "wof:geomhash":"3441fe0d3e0af95e4fd8552b8830f872",
+    "wof:geomhash":"4806b3f7ffeab6c5284f320e3a13efa9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -245,7 +246,7 @@
         }
     ],
     "wof:id":1092049883,
-    "wof:lastmodified":1690849705,
+    "wof:lastmodified":1695886622,
     "wof:name":"Bhojpur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/992/3/1092049923.geojson
+++ b/data/109/204/992/3/1092049923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107564,
-    "geom:area_square_m":1188734533.729491,
+    "geom:area_square_m":1188734789.431078,
     "geom:bbox":"86.919436,26.399165,87.35312,26.878021",
     "geom:latitude":26.650863,
     "geom:longitude":87.171979,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.ON.SN",
         "wd:id":"Q28157"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898505,
-    "wof:geomhash":"025282dffe3233cd2929c92c07de7700",
+    "wof:geomhash":"65fc66c20cc28dad1df1555ab1e8bd02",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092049923,
-    "wof:lastmodified":1690849698,
+    "wof:lastmodified":1695886587,
     "wof:name":"Sunsari",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/204/996/3/1092049963.geojson
+++ b/data/109/204/996/3/1092049963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229812,
-    "geom:area_square_m":2493948583.268925,
+    "geom:area_square_m":2493947956.110222,
     "geom:bbox":"80.982418,28.339319,82.030013,28.976162",
     "geom:latitude":28.641502,
     "geom:longitude":81.585515,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.FI.SU",
         "wd:id":"Q28589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898507,
-    "wof:geomhash":"812cc229c534db34819be38aa1e120be",
+    "wof:geomhash":"2cd900121d8086558a78dfe5adc303ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092049963,
-    "wof:lastmodified":1690849692,
+    "wof:lastmodified":1695886585,
     "wof:name":"Surkhet",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/000/9/1092050009.geojson
+++ b/data/109/205/000/9/1092050009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153296,
-    "geom:area_square_m":1669142233.796344,
+    "geom:area_square_m":1669142233.796459,
     "geom:bbox":"84.1884312616,28.06,84.6924947869,28.511705857",
     "geom:latitude":28.289529,
     "geom:longitude":84.430095,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"NP.FO.LM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898509,
-    "wof:geomhash":"c93fec5c54f17effe2438959d6b76b64",
+    "wof:geomhash":"1153dd29b7f2235e91ec93c95ff7e5ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092050009,
-    "wof:lastmodified":1566669769,
+    "wof:lastmodified":1695886591,
     "wof:name":"Lamjung",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/005/3/1092050053.geojson
+++ b/data/109/205/005/3/1092050053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14413,
-    "geom:area_square_m":1574228382.426883,
+    "geom:area_square_m":1574228121.999535,
     "geom:bbox":"83.937008,27.741105,84.557724,28.129436",
     "geom:latitude":27.955765,
     "geom:longitude":84.250274,
@@ -189,9 +189,10 @@
         "hasc:id":"NP.FO.TN",
         "wd:id":"Q28446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898510,
-    "wof:geomhash":"6964c85dd00e24b96e241555eb5a101b",
+    "wof:geomhash":"9daf809bcd86573981aad396aeb64a9a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":1092050053,
-    "wof:lastmodified":1690849711,
+    "wof:lastmodified":1695886592,
     "wof:name":"Tanahu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/010/1/1092050101.geojson
+++ b/data/109/205/010/1/1092050101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.203621,
-    "geom:area_square_m":2231582470.097742,
+    "geom:area_square_m":2231582908.452597,
     "geom:bbox":"83.91782,27.357373,84.794267,27.879889",
     "geom:latitude":27.585783,
     "geom:longitude":84.436581,
@@ -165,9 +165,10 @@
         "hasc:id":"NP.TH.CH",
         "wd:id":"Q28583"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898512,
-    "wof:geomhash":"b3d3b332b37a9e5018a27005db0bd28a",
+    "wof:geomhash":"8aea560a241582477be96a7ed6361d6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":1092050101,
-    "wof:lastmodified":1690849710,
+    "wof:lastmodified":1695886591,
     "wof:name":"Chitwan",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/013/7/1092050137.geojson
+++ b/data/109/205/013/7/1092050137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061108,
-    "geom:area_square_m":672333306.538241,
+    "geom:area_square_m":672333370.50642,
     "geom:bbox":"87.391702,26.968686,87.751363,27.297855",
     "geom:latitude":27.154449,
     "geom:longitude":87.548951,
@@ -198,9 +198,10 @@
         "hasc:id":"NP.ON.TR",
         "wd:id":"Q28585"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898514,
-    "wof:geomhash":"9715d9159ac35daa514ca8071fa9ddbd",
+    "wof:geomhash":"7824c882f56f33569c67d323f0caddf6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":1092050137,
-    "wof:lastmodified":1690849707,
+    "wof:lastmodified":1695886590,
     "wof:name":"Terhathum",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/017/9/1092050179.geojson
+++ b/data/109/205/017/9/1092050179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208923,
-    "geom:area_square_m":2303781405.170978,
+    "geom:area_square_m":2303781591.484173,
     "geom:bbox":"86.15496,26.688791,87.171427,27.179296",
     "geom:latitude":26.902952,
     "geom:longitude":86.680243,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.ON.UD",
         "wd:id":"Q28582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898515,
-    "wof:geomhash":"1509e24ef01ef95aeae81136c1609670",
+    "wof:geomhash":"7bf85d821d77a764c6edc598aa026b8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092050179,
-    "wof:lastmodified":1690849709,
+    "wof:lastmodified":1695886591,
     "wof:name":"Udayapur",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/022/5/1092050225.geojson
+++ b/data/109/205/022/5/1092050225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097907,
-    "geom:area_square_m":1075505036.733946,
+    "geom:area_square_m":1075504922.985088,
     "geom:bbox":"86.202542,27.145054,86.684747,27.525467",
     "geom:latitude":27.329833,
     "geom:longitude":86.418211,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.ON.OK",
         "wd:id":"Q29026"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898516,
-    "wof:geomhash":"5b46c658b27425ed912059cef34955c4",
+    "wof:geomhash":"a706765ab7447a17b115b500372dbfd6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092050225,
-    "wof:lastmodified":1690849707,
+    "wof:lastmodified":1695886590,
     "wof:name":"Okhaldhunga",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/025/5/1092050255.geojson
+++ b/data/109/205/025/5/1092050255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140708,
-    "geom:area_square_m":1514217827.61662,
+    "geom:area_square_m":1514218127.985653,
     "geom:bbox":"80.236388,29.308216,80.902497,29.708213",
     "geom:latitude":29.506096,
     "geom:longitude":80.567458,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.SE.BT",
         "wd:id":"Q28076"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898518,
-    "wof:geomhash":"b1745976872cd2ba2f8b61ad782edbda",
+    "wof:geomhash":"0f6444cdb7abe621f44a31493ccbd639",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092050255,
-    "wof:lastmodified":1690849707,
+    "wof:lastmodified":1695886590,
     "wof:name":"Baitadi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/029/7/1092050297.geojson
+++ b/data/109/205/029/7/1092050297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176074,
-    "geom:area_square_m":1920843288.588712,
+    "geom:area_square_m":1920843373.364471,
     "geom:bbox":"81.500658,27.852499,82.193317,28.333635",
     "geom:latitude":28.084063,
     "geom:longitude":81.822484,
@@ -155,9 +155,10 @@
         "hasc:id":"NP.FI.BN",
         "wd:id":"Q28447"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898519,
-    "wof:geomhash":"30361f8ab918a0a3099e3f92039ccb55",
+    "wof:geomhash":"7db0b0aef188e8ff10f03188cd1195ce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":1092050297,
-    "wof:lastmodified":1690849709,
+    "wof:lastmodified":1695886591,
     "wof:name":"Banke",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/034/7/1092050347.geojson
+++ b/data/109/205/034/7/1092050347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214529,
-    "geom:area_square_m":2299937380.897664,
+    "geom:area_square_m":2299937575.556906,
     "geom:bbox":"80.373055,29.612174,81.109038,30.22784",
     "geom:latitude":29.885492,
     "geom:longitude":80.787546,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.SE.DR",
         "wd:id":"Q28601"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898522,
-    "wof:geomhash":"ef01500871a381002e769677b3444894",
+    "wof:geomhash":"4670a56376b6b8427107852d52b6939a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092050347,
-    "wof:lastmodified":1690849711,
+    "wof:lastmodified":1695886592,
     "wof:name":"Darchula",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/034/9/1092050349.geojson
+++ b/data/109/205/034/9/1092050349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.735892,
-    "geom:area_square_m":7945284723.166389,
+    "geom:area_square_m":7945284730.698092,
     "geom:bbox":"82.393431,28.725379,83.678701,29.707412",
     "geom:latitude":29.171155,
     "geom:longitude":83.052087,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.SI.DP",
         "wd:id":"Q28610"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898523,
-    "wof:geomhash":"ace1d50dcfff07cfd38c3f3068a4ec99",
+    "wof:geomhash":"5776e2ec8bc0a33310369a55750c3266",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092050349,
-    "wof:lastmodified":1690849711,
+    "wof:lastmodified":1695886592,
     "wof:name":"Dolpa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/035/1/1092050351.geojson
+++ b/data/109/205/035/1/1092050351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.335116,
-    "geom:area_square_m":3647819932.925405,
+    "geom:area_square_m":3647819919.182528,
     "geom:bbox":"84.420364,27.797434,85.197831,28.75157",
     "geom:latitude":28.318847,
     "geom:longitude":84.790019,
@@ -170,9 +170,10 @@
         "hasc:id":"NP.FO.GO",
         "wd:id":"Q28476"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898524,
-    "wof:geomhash":"69c845e4dcfba505da5ced13901569fc",
+    "wof:geomhash":"1784bd6fc176d93a3008a35dd7295985",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1092050351,
-    "wof:lastmodified":1690849710,
+    "wof:lastmodified":1695886592,
     "wof:name":"Gorkha",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/035/3/1092050353.geojson
+++ b/data/109/205/035/3/1092050353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.561445,
-    "geom:area_square_m":6010266726.838093,
+    "geom:area_square_m":6010266409.401609,
     "geom:bbox":"81.256219,29.606249,82.500728,30.446945",
     "geom:latitude":30.032603,
     "geom:longitude":81.879617,
@@ -176,9 +176,10 @@
         "hasc:id":"NP.SI.HU",
         "wd:id":"Q28623"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898526,
-    "wof:geomhash":"bbed86e2ec88bfbe50f796828e1dbba3",
+    "wof:geomhash":"5edf79ccc3b6e7c52fc5c6d4e6a4c204",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":1092050353,
-    "wof:lastmodified":1690849710,
+    "wof:lastmodified":1695886592,
     "wof:name":"Humla",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/036/7/1092050367.geojson
+++ b/data/109/205/036/7/1092050367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145972,
-    "geom:area_square_m":1614155975.806242,
+    "geom:area_square_m":1614155975.80576,
     "geom:bbox":"87.6379460427,26.36117775,88.187537,26.7935344779",
     "geom:latitude":26.58302,
     "geom:longitude":87.912053,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"NP.ON.JH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898527,
-    "wof:geomhash":"8d2419a2402598ac31f41b4c00af6b25",
+    "wof:geomhash":"9b836de6f20a48bcfd7621481e9037b6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1092050367,
-    "wof:lastmodified":1566669769,
+    "wof:lastmodified":1695886591,
     "wof:name":"Jhapa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/041/3/1092050413.geojson
+++ b/data/109/205/041/3/1092050413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194534,
-    "geom:area_square_m":2131011672.203375,
+    "geom:area_square_m":2131011873.614952,
     "geom:bbox":"83.572926,27.353199,84.429771,27.868431",
     "geom:latitude":27.636383,
     "geom:longitude":83.953575,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.FO.NA",
         "wd:id":"Q28588"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898529,
-    "wof:geomhash":"4290f5e17d814ad3aa571aa390f5a52a",
+    "wof:geomhash":"0a3ff3477eb210c04bc07f39e494e292",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092050413,
-    "wof:lastmodified":1690849706,
+    "wof:lastmodified":1695886590,
     "wof:name":"Nawalparasi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/045/3/1092050453.geojson
+++ b/data/109/205/045/3/1092050453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128787,
-    "geom:area_square_m":1415870193.7164,
+    "geom:area_square_m":1415870108.741883,
     "geom:bbox":"84.484413,26.984958,84.972011,27.461299",
     "geom:latitude":27.239728,
     "geom:longitude":84.779267,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.TW.PR",
         "wd:id":"Q28625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898530,
-    "wof:geomhash":"248b4f5bf8cd0fe735861c1ce7922402",
+    "wof:geomhash":"0a0c58e3053bbda06071b7f863d6c2dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092050453,
-    "wof:lastmodified":1690849708,
+    "wof:lastmodified":1695886591,
     "wof:name":"Parsa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/049/7/1092050497.geojson
+++ b/data/109/205/049/7/1092050497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106274,
-    "geom:area_square_m":1173551379.928227,
+    "geom:area_square_m":1173551739.502511,
     "geom:bbox":"86.129836,26.542073,86.552325,26.932135",
     "geom:latitude":26.741642,
     "geom:longitude":86.342773,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.TW.SR",
         "wd:id":"Q28088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898532,
-    "wof:geomhash":"50bcabf0dde329b4ac8529159c33a015",
+    "wof:geomhash":"519b6bfe7154295b6c5c2c34ae1405fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092050497,
-    "wof:lastmodified":1690849708,
+    "wof:lastmodified":1695886590,
     "wof:name":"Siraha",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/053/5/1092050535.geojson
+++ b/data/109/205/053/5/1092050535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196417,
-    "geom:area_square_m":2148682614.650506,
+    "geom:area_square_m":2148683134.487374,
     "geom:bbox":"85.885655,27.478993,86.553069,28.173806",
     "geom:latitude":27.785735,
     "geom:longitude":86.198413,
@@ -173,9 +173,10 @@
         "hasc:id":"NP.TH.DO",
         "wd:id":"Q28621"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898533,
-    "wof:geomhash":"5dc0bfeb2edfb2d9f5ec8d50c21e76c5",
+    "wof:geomhash":"b90a708112a9eb2efddb34a5b675fd6f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1092050535,
-    "wof:lastmodified":1690849708,
+    "wof:lastmodified":1695886590,
     "wof:name":"Dolakha",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/058/3/1092050583.geojson
+++ b/data/109/205/058/3/1092050583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137061,
-    "geom:area_square_m":1483981702.376503,
+    "geom:area_square_m":1483981784.091182,
     "geom:bbox":"81.416548,28.63518,81.926316,29.131753",
     "geom:latitude":28.881584,
     "geom:longitude":81.678427,
@@ -161,9 +161,10 @@
         "hasc:id":"NP.SI.DL",
         "wd:id":"Q28443"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898535,
-    "wof:geomhash":"39a175361360207b177b5d4f76610ca5",
+    "wof:geomhash":"9ec5e62ff440f6f04fcd437dfd89335a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":1092050583,
-    "wof:lastmodified":1690849712,
+    "wof:lastmodified":1695886592,
     "wof:name":"Dailekh",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/062/7/1092050627.geojson
+++ b/data/109/205/062/7/1092050627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214455,
-    "geom:area_square_m":2306570019.367836,
+    "geom:area_square_m":2306569596.264512,
     "geom:bbox":"81.170472,29.269657,81.807275,29.948885",
     "geom:latitude":29.561645,
     "geom:longitude":81.563074,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.SE.BU",
         "wd:id":"Q28071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898536,
-    "wof:geomhash":"98daa96e63d0374395a9e8d4ff3d139e",
+    "wof:geomhash":"3121bbad710e11969f5847ee5a97e3fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092050627,
-    "wof:lastmodified":1690849708,
+    "wof:lastmodified":1695886591,
     "wof:name":"Bajura",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/066/1/1092050661.geojson
+++ b/data/109/205/066/1/1092050661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.174886,
-    "geom:area_square_m":1910159117.906695,
+    "geom:area_square_m":1910159058.691297,
     "geom:bbox":"84.62393,27.670394,85.269248,28.348131",
     "geom:latitude":27.955049,
     "geom:longitude":84.959887,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TH.DH",
         "wd:id":"Q28454"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898537,
-    "wof:geomhash":"a21ae2ff0ccf05a42de28fcf63de5ea7",
+    "wof:geomhash":"4f69e3ce1225cb4366335b4491a17123",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092050661,
-    "wof:lastmodified":1690849710,
+    "wof:lastmodified":1695886592,
     "wof:name":"Dhading",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/070/9/1092050709.geojson
+++ b/data/109/205/070/9/1092050709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091665,
-    "geom:area_square_m":1011009292.11059,
+    "geom:area_square_m":1011009484.953692,
     "geom:bbox":"85.674337,26.59931,85.944539,27.168155",
     "geom:latitude":26.878205,
     "geom:longitude":85.819021,
@@ -167,9 +167,10 @@
         "hasc:id":"NP.TW.MH",
         "wd:id":"Q28618"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898539,
-    "wof:geomhash":"51be93e71b28a95b640e256a6b61996d",
+    "wof:geomhash":"17e0c592cfac8883eb49a858bcc52f84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":1092050709,
-    "wof:lastmodified":1690849707,
+    "wof:lastmodified":1695886591,
     "wof:name":"Mahottari",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/075/5/1092050755.geojson
+++ b/data/109/205/075/5/1092050755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101684,
-    "geom:area_square_m":1109191559.846778,
+    "geom:area_square_m":1109191295.419842,
     "geom:bbox":"83.025172,27.919779,83.606315,28.270652",
     "geom:latitude":28.094046,
     "geom:longitude":83.306298,
@@ -158,9 +158,10 @@
         "hasc:id":"NP.FI.GU",
         "wd:id":"Q28572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898540,
-    "wof:geomhash":"029c1f45d86f4851807c07cd5f991470",
+    "wof:geomhash":"26b2edf8e036852f2ddf41d3be445318",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1092050755,
-    "wof:lastmodified":1690849709,
+    "wof:lastmodified":1695886591,
     "wof:name":"Gulmi",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/079/7/1092050797.geojson
+++ b/data/109/205/079/7/1092050797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236829,
-    "geom:area_square_m":2554508568.657603,
+    "geom:area_square_m":2554508572.790603,
     "geom:bbox":"81.847346,28.970602,82.59158,29.510096",
     "geom:latitude":29.271363,
     "geom:longitude":82.217241,
@@ -191,9 +191,10 @@
         "hasc:id":"NP.SI.JU",
         "wd:id":"Q28619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898542,
-    "wof:geomhash":"16acfe9db60bbda45147506a3e980224",
+    "wof:geomhash":"53c709f00a66ffaf8e0e0cec535a63f9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":1092050797,
-    "wof:lastmodified":1690849706,
+    "wof:lastmodified":1695886622,
     "wof:name":"Jumla",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/084/1/1092050841.geojson
+++ b/data/109/205/084/1/1092050841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144998,
-    "geom:area_square_m":1595117956.377048,
+    "geom:area_square_m":1595117635.87635,
     "geom:bbox":"86.431974,26.87025,86.979178,27.437012",
     "geom:latitude":27.167994,
     "geom:longitude":86.786859,
@@ -164,9 +164,10 @@
         "hasc:id":"NP.ON.KH",
         "wd:id":"Q28599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898543,
-    "wof:geomhash":"98794e5b10f633829c0b571daa8ccf50",
+    "wof:geomhash":"ce814ea4e0b20eb14675ab6bc0c08839",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":1092050841,
-    "wof:lastmodified":1690849706,
+    "wof:lastmodified":1695886590,
     "wof:name":"Khotang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/088/9/1092050889.geojson
+++ b/data/109/205/088/9/1092050889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133831,
-    "geom:area_square_m":1463615988.338318,
+    "geom:area_square_m":1463616217.668619,
     "geom:bbox":"83.237517,27.663607,84.026601,27.958146",
     "geom:latitude":27.817164,
     "geom:longitude":83.623517,
@@ -152,9 +152,10 @@
         "hasc:id":"NP.FI.PL",
         "wd:id":"Q28440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898545,
-    "wof:geomhash":"63a40d04c38dabbe943ac510163d77fd",
+    "wof:geomhash":"ee8bff25ad8ab7c47edfe73eafdd1be5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1092050889,
-    "wof:lastmodified":1690849709,
+    "wof:lastmodified":1695886591,
     "wof:name":"Palpa",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/205/093/9/1092050939.geojson
+++ b/data/109/205/093/9/1092050939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095307,
-    "geom:area_square_m":1040341675.462415,
+    "geom:area_square_m":1040342024.96594,
     "geom:bbox":"83.438895,27.868098,84.028329,28.220814",
     "geom:latitude":28.020927,
     "geom:longitude":83.802289,
@@ -170,9 +170,10 @@
         "hasc:id":"NP.FO.SY",
         "wd:id":"Q28448"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NP",
     "wof:created":1473898546,
-    "wof:geomhash":"c240829c6ec39784e2e34f3a6979ff44",
+    "wof:geomhash":"3bee336b17e88b9d30e93fc94113c18d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":1092050939,
-    "wof:lastmodified":1690849712,
+    "wof:lastmodified":1695886592,
     "wof:name":"Syangja",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/880/712/9/1108807129.geojson
+++ b/data/110/880/712/9/1108807129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.088448,
-    "geom:area_square_m":22719337297.485039,
+    "geom:area_square_m":22719338157.153595,
     "geom:bbox":"82.878881,27.353199,85.197831,29.330612",
     "geom:latitude":28.382314,
     "geom:longitude":84.039539,
@@ -23,7 +23,7 @@
     "lbl:longitude":84.022322,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -55,11 +55,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-FO",
-        "hasc:id":"NP.FO"
+        "hasc:id":"NP.FO",
+        "iso:code":"NP-P4"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064899,
-    "wof:geomhash":"fc9d581be2a3c9e4af2658f3161ce477",
+    "wof:geomhash":"cc71f6fd04353270ded371b6723e9e54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +76,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 4",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/713/1/1108807131.geojson
+++ b/data/110/880/713/1/1108807131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.06014,
-    "geom:area_square_m":22455994733.150421,
+    "geom:area_square_m":22455994047.584145,
     "geom:bbox":"80.982418,27.335555,84.026601,28.993303",
     "geom:latitude":28.170828,
     "geom:longitude":82.512735,
@@ -23,7 +23,7 @@
     "lbl:longitude":82.742907,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:ben_x_preferred":[
@@ -76,11 +76,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-FI",
-        "hasc:id":"NP.FI"
+        "hasc:id":"NP.FI",
+        "iso:code":"NP-P5"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064902,
-    "wof:geomhash":"a10a9f1616a8ed126b8a025060791be1",
+    "wof:geomhash":"4251ffc1eb641f5e18d8504df015a622",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +97,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 5",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/713/3/1108807133.geojson
+++ b/data/110/880/713/3/1108807133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.504021,
-    "geom:area_square_m":26991330877.336975,
+    "geom:area_square_m":26991330592.371494,
     "geom:bbox":"81.256219,28.185323,83.678701,30.446945",
     "geom:latitude":29.335094,
     "geom:longitude":82.33848,
@@ -23,7 +23,7 @@
     "lbl:longitude":82.320052,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -55,11 +55,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-SI",
-        "hasc:id":"NP.SI"
+        "hasc:id":"NP.SI",
+        "iso:code":"NP-P6"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064905,
-    "wof:geomhash":"a5905900893bf255ddf77116eccbc8af",
+    "wof:geomhash":"95c902d3fc7e3c2d4c15479c40e938ee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +76,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 6",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/713/5/1108807135.geojson
+++ b/data/110/880/713/5/1108807135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.838842,
-    "geom:area_square_m":19824170875.364834,
+    "geom:area_square_m":19824171070.15353,
     "geom:bbox":"80.052222,28.400825,81.807275,30.22784",
     "geom:latitude":29.32112,
     "geom:longitude":80.937549,
@@ -23,7 +23,7 @@
     "lbl:longitude":80.924421,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -55,11 +55,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-SE",
-        "hasc:id":"NP.SE"
+        "hasc:id":"NP.SE",
+        "iso:code":"NP-P7"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064906,
-    "wof:geomhash":"c498e539d36ad7137c7c7e800f659ea7",
+    "wof:geomhash":"6072fdaeccc6980c90893ea8c4fc92bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -74,7 +76,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522479,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 7",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/713/9/1108807139.geojson
+++ b/data/110/880/713/9/1108807139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.377487,
-    "geom:area_square_m":26144139881.102818,
+    "geom:area_square_m":26144139510.109608,
     "geom:bbox":"86.15496,26.347779,88.199298,28.11375",
     "geom:latitude":27.209891,
     "geom:longitude":87.272343,
@@ -23,7 +23,7 @@
     "lbl:longitude":87.291339,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -70,11 +70,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-ON",
-        "hasc:id":"NP.ON"
+        "hasc:id":"NP.ON",
+        "iso:code":"NP-P1"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064907,
-    "wof:geomhash":"e1ca49def2d80f28cf7b185a7fadbd20",
+    "wof:geomhash":"4bab193d8eaf0c6addbda246bfb4411c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -89,7 +91,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 1",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/714/1/1108807141.geojson
+++ b/data/110/880/714/1/1108807141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.880133,
-    "geom:area_square_m":9702951787.689545,
+    "geom:area_square_m":9702951595.315231,
     "geom:bbox":"84.484413,26.419723,87.013187,27.461299",
     "geom:latitude":26.928123,
     "geom:longitude":85.691891,
@@ -23,7 +23,7 @@
     "lbl:longitude":85.356931,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:eng_x_preferred":[
@@ -70,11 +70,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-TW",
-        "hasc:id":"NP.TW"
+        "hasc:id":"NP.TW",
+        "iso:code":"NP-P2"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064909,
-    "wof:geomhash":"98a01e201aba27c5d6b87f951815a572",
+    "wof:geomhash":"62d6253fac2cc151e59018515982268f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -89,7 +91,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522479,
+    "wof:lastmodified":1695884285,
     "wof:name":"Province No. 2",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/110/880/714/3/1108807143.geojson
+++ b/data/110/880/714/3/1108807143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.855449,
-    "geom:area_square_m":20317248623.163578,
+    "geom:area_square_m":20317248968.153358,
     "geom:bbox":"83.91782,26.925919,86.571415,28.385833",
     "geom:latitude":27.678766,
     "geom:longitude":85.470968,
@@ -23,7 +23,7 @@
     "lbl:longitude":85.451076,
     "lbl:min_zoom":8.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":7.7,
     "name:ben_x_preferred":[
@@ -73,11 +73,13 @@
     "wof:breaches":[],
     "wof:concordances":{
         "fips:code":"NP-TH",
-        "hasc:id":"NP.TH"
+        "hasc:id":"NP.TH",
+        "iso:code":"NP-P3"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:created":1486064910,
-    "wof:geomhash":"5833aeb4e13768c6e81206e31eb4666f",
+    "wof:geomhash":"c765bbec143fb4a0776246c7e6556699",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -92,7 +94,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1627522478,
+    "wof:lastmodified":1695884284,
     "wof:name":"Province No. 3",
     "wof:parent_id":85632465,
     "wof:placetype":"region",

--- a/data/856/324/65/85632465.geojson
+++ b/data/856/324/65/85632465.geojson
@@ -1174,6 +1174,7 @@
         "hasc:id":"NP",
         "icao:code":"9N",
         "ioc:id":"NEP",
+        "iso:code":"NP",
         "itu:id":"NPL",
         "loc:id":"n79091522",
         "m49:code":"524",
@@ -1188,6 +1189,7 @@
         "wk:page":"Nepal",
         "wmo:id":"NP"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NP",
     "wof:country_alpha3":"NPL",
     "wof:geom_alt":[
@@ -1209,7 +1211,7 @@
     "wof:lang_x_spoken":[
         "nep"
     ],
-    "wof:lastmodified":1694639503,
+    "wof:lastmodified":1695881158,
     "wof:name":"Nepal",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.